### PR TITLE
Add an optional TypeReferenceResolver, bypassing assembly reference resolution

### DIFF
--- a/Sources/DotNetMetadata/ExportedType.swift
+++ b/Sources/DotNetMetadata/ExportedType.swift
@@ -38,13 +38,15 @@ public final class ExportedType {
             }
             switch try implementationCodedIndex.tag {
                 case .assemblyRef:
-                    let definitionAssembly = try self.assembly.resolveAssemblyRef(rowIndex: implementationRowIndex)
+                    let assemblyReference = try self.assembly.resolveAssemblyRef(rowIndex: implementationRowIndex)
                     // TODO: Optimize using the typeDefId field
                     // TODO: Support recursive exported types
-                    guard let typeDefinition = try definitionAssembly.resolveTypeDefinition(namespace: namespace, name: name) else {
-                        throw DotNetMetadataFormat.InvalidFormatError.tableConstraint
-                    }
-                    return typeDefinition
+                    let typeReference = AssemblyLoadContext.TypeReference(
+                        assembly: assemblyReference.identity,
+                        assemblyFlags: assemblyReference.flags,
+                        namespace: namespace,
+                        name: name)
+                    return try context.resolve(typeReference)
                 default:
                     fatalError("Not implemented: \(#function)")
             }

--- a/Tests/DotNetMetadata/Utilities/CSharpCompilation.swift
+++ b/Tests/DotNetMetadata/Utilities/CSharpCompilation.swift
@@ -45,9 +45,9 @@ class CSharpCompilation {
         guard result.exitCode == 0 else { throw CompilerError(message: result.standardOutput) }
 
         // Resolve the core library if tests require it
-        assemblyLoadContext = AssemblyLoadContext(resolver: {
-            guard $0.name.starts(with: "System.") else { throw AssemblyLoadError.notFound(message: "Unexpected assembly reference.") }
-            return try ModuleFile(path: "\(refsPath)\\\($0.name).dll")
+        assemblyLoadContext = AssemblyLoadContext(referenceResolver: { identity, flags in
+            guard identity.name.starts(with: "System.") else { throw AssemblyLoadError.notFound(message: "Unexpected assembly reference.") }
+            return try ModuleFile(path: "\(refsPath)\\\(identity.name).dll")
         })
 
         assembly = try assemblyLoadContext.load(path: assemblyFilePath)

--- a/Tests/WindowsMetadata/WinMetadataTests.swift
+++ b/Tests/WindowsMetadata/WinMetadataTests.swift
@@ -13,7 +13,7 @@ final class WinMetadataTests: XCTestCase {
         guard let windowsFoundationPath = SystemAssemblies.WinMetadata.windowsFoundationPath else { return }
         let url = URL(fileURLWithPath: windowsFoundationPath)
 
-        context = AssemblyLoadContext(resolver: { _ in throw AssemblyLoadError.notFound() })
+        context = AssemblyLoadContext()
         // Resolve the mscorlib dependency from the .NET Framework 4 machine installation
         if let mscorlibPath = SystemAssemblies.DotNetFramework4.mscorlibPath {
             mscorlib = try? context.load(path: mscorlibPath)


### PR DESCRIPTION
This is useful for WinMD files where assembly references tend to be bogus or not correspond to the file on disk that should be loaded.

Fixes #25