### PR TITLE
Rename AssemblyVersion to FourPartVersion

### DIFF
--- a/Sources/DotNetMetadata/Assembly.swift
+++ b/Sources/DotNetMetadata/Assembly.swift
@@ -13,7 +13,7 @@ public class Assembly: CustomDebugStringConvertible {
 
     public var name: String { moduleFile.resolve(tableRow.name) }
 
-    public var version: AssemblyVersion {
+    public var version: FourPartVersion {
         .init(
             major: tableRow.majorVersion,
             minor: tableRow.minorVersion,

--- a/Sources/DotNetMetadata/AssemblyReference.swift
+++ b/Sources/DotNetMetadata/AssemblyReference.swift
@@ -13,7 +13,7 @@ public final class AssemblyReference {
     internal var tableRow: AssemblyRefTable.Row { moduleFile.assemblyRefTable[tableRowIndex] }
 
     public var name: String { moduleFile.resolve(tableRow.name) }
-    public var version: AssemblyVersion { tableRow.version }
+    public var version: FourPartVersion { tableRow.version }
 
     public var culture: String? {
         let culture = moduleFile.resolve(tableRow.culture)

--- a/Sources/DotNetMetadata/Reexported.swift
+++ b/Sources/DotNetMetadata/Reexported.swift
@@ -2,7 +2,7 @@ import DotNetMetadataFormat
 
 public typealias AssemblyIdentity = DotNetMetadataFormat.AssemblyIdentity
 public typealias AssemblyPublicKey = DotNetMetadataFormat.AssemblyPublicKey
-public typealias AssemblyVersion = DotNetMetadataFormat.AssemblyVersion
+public typealias FourPartVersion = DotNetMetadataFormat.FourPartVersion
 public typealias Constant = DotNetMetadataFormat.Constant
 public typealias IntegerSize = DotNetMetadataFormat.IntegerSize
 public typealias LayoutKind = DotNetMetadataFormat.LayoutKind

--- a/Sources/DotNetMetadataFormat/AssemblyIdentity.swift
+++ b/Sources/DotNetMetadataFormat/AssemblyIdentity.swift
@@ -5,11 +5,11 @@ public struct AssemblyIdentity: Hashable, CustomStringConvertible {
 
     public var name: String
     // Version should always be present in definitions, but is allowed to be null for references
-    public var version: AssemblyVersion?
+    public var version: FourPartVersion?
     public var culture: String?
     public var publicKey: AssemblyPublicKey?
 
-    public init(name: String, version: AssemblyVersion? = nil, culture: String? = nil, publicKey: AssemblyPublicKey? = nil) {
+    public init(name: String, version: FourPartVersion? = nil, culture: String? = nil, publicKey: AssemblyPublicKey? = nil) {
         self.name = name
         self.version = version
         self.culture = culture
@@ -49,9 +49,9 @@ public struct AssemblyIdentity: Hashable, CustomStringConvertible {
         let name = String(segments[0])
         var index = 1
 
-        let version: AssemblyVersion?
+        let version: FourPartVersion?
         if index < segments.count, let match = try segments[index].wholeMatch(of: Regex(#"Version=(\d+)\.(\d+)\.(\d+)\.(\d+)"#)) {
-            version = AssemblyVersion(
+            version = FourPartVersion(
                 major: UInt16(match[1].substring!)!,
                 minor: UInt16(match[2].substring!)!,
                 buildNumber: UInt16(match[3].substring!)!,

--- a/Sources/DotNetMetadataFormat/FourPartVersion.swift
+++ b/Sources/DotNetMetadataFormat/FourPartVersion.swift
@@ -1,6 +1,6 @@
-public struct AssemblyVersion: Comparable, Hashable, CustomStringConvertible {
-    public static let zero = AssemblyVersion()
-    public static let all255 = AssemblyVersion(major: 255, minor: 255, buildNumber: 255, revisionNumber: 255)
+public struct FourPartVersion: Comparable, Hashable, CustomStringConvertible {
+    public static let zero = FourPartVersion()
+    public static let all255 = FourPartVersion(major: 255, minor: 255, buildNumber: 255, revisionNumber: 255)
 
     public var major: UInt16
     public var minor: UInt16
@@ -23,7 +23,7 @@ public struct AssemblyVersion: Comparable, Hashable, CustomStringConvertible {
         self.revisionNumber = revisionNumber
     }
 
-    public static func < (lhs: AssemblyVersion, rhs: AssemblyVersion) -> Bool {
+    public static func < (lhs: FourPartVersion, rhs: FourPartVersion) -> Bool {
         if lhs.major != rhs.major {
             return lhs.major < rhs.major
         } else if lhs.minor != rhs.minor {

--- a/Sources/DotNetMetadataFormat/TableRows.swift
+++ b/Sources/DotNetMetadataFormat/TableRows.swift
@@ -7,7 +7,7 @@ public enum TableRows {
         public var name: StringHeap.Offset
         public var culture: StringHeap.Offset
 
-        public var version: AssemblyVersion {
+        public var version: FourPartVersion {
             .init(
                 major: majorVersion,
                 minor: minorVersion,
@@ -24,7 +24,7 @@ public enum TableRows {
         public var culture: StringHeap.Offset
         public var hashValue: BlobHeap.Offset
         
-        public var version: AssemblyVersion {
+        public var version: FourPartVersion {
             .init(
                 major: majorVersion,
                 minor: minorVersion,

--- a/Tests/DotNetMetadataFormat/AssemblyIdentityTests.swift
+++ b/Tests/DotNetMetadataFormat/AssemblyIdentityTests.swift
@@ -15,7 +15,7 @@ final class AssemblyIdentityTests: XCTestCase {
     func testParse() throws {
         let value = try AssemblyIdentity.parse("mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")
         XCTAssertEqual(value.name, "mscorlib")
-        XCTAssertEqual(value.version, AssemblyVersion(major: 2, minor: 0, buildNumber: 0, revisionNumber: 0))
+        XCTAssertEqual(value.version, FourPartVersion(major: 2, minor: 0, buildNumber: 0, revisionNumber: 0))
         XCTAssertEqual(value.culture, "neutral")
         XCTAssertEqual(value.publicKey, .token([ 0xb7, 0x7a, 0x5c, 0x56, 0x19, 0x34, 0xe0, 0x89 ]))
     }


### PR DESCRIPTION
So it can be reused in non-assembly contexts such as UAP API contracts