### PR TITLE
AssemblyLoadContext: remove custom type resolution in favor of UWP-specific logic

### DIFF
--- a/Sources/DotNetMetadata/Assembly+resolve.swift
+++ b/Sources/DotNetMetadata/Assembly+resolve.swift
@@ -57,12 +57,11 @@ extension Assembly {
                     throw DotNetMetadataFormat.InvalidFormatError.tableConstraint
                 }
                 let assemblyReference = try resolveAssemblyRef(rowIndex: assemblyRefRowIndex)
-                let typeReference = AssemblyLoadContext.TypeReference(
+                return try context.resolveType(
                     assembly: assemblyReference.identity,
                     assemblyFlags: assemblyReference.flags,
                     namespace: namespace,
                     name: name)
-                return try context.resolve(typeReference)
             default:
                 fatalError("Not implemented: resolution scope \(row.resolutionScope)")
         }

--- a/Sources/DotNetMetadata/Assembly.swift
+++ b/Sources/DotNetMetadata/Assembly.swift
@@ -36,6 +36,8 @@ public class Assembly: CustomDebugStringConvertible {
         AssemblyIdentity(name: name, version: version, culture: culture, publicKey: publicKey)
     }
 
+    public var flags: AssemblyFlags { tableRow.flags }
+
     public var debugDescription: String { identity.description}
 
     private var cachedModuleName: String?

--- a/Sources/DotNetMetadata/ExportedType.swift
+++ b/Sources/DotNetMetadata/ExportedType.swift
@@ -41,12 +41,11 @@ public final class ExportedType {
                     let assemblyReference = try self.assembly.resolveAssemblyRef(rowIndex: implementationRowIndex)
                     // TODO: Optimize using the typeDefId field
                     // TODO: Support recursive exported types
-                    let typeReference = AssemblyLoadContext.TypeReference(
+                    return try context.resolveType(
                         assembly: assemblyReference.identity,
                         assemblyFlags: assemblyReference.flags,
                         namespace: namespace,
                         name: name)
-                    return try context.resolve(typeReference)
                 default:
                     fatalError("Not implemented: \(#function)")
             }

--- a/Sources/DotNetMetadataFormat/AssemblyEnums.swift
+++ b/Sources/DotNetMetadataFormat/AssemblyEnums.swift
@@ -8,6 +8,7 @@ public struct AssemblyFlags: OptionSet {
     public static let sideBySideCompatible = Self(rawValue: 0x2)
     public static let reserved = Self(rawValue: 0x30)
     public static let retargetable = Self(rawValue: 0x100)
+    public static let windowsRuntime = Self(rawValue: 0x200)
     public static let disableJITcompileOptimizer = Self(rawValue: 0x4000)
     public static let enableJITCompileTracking = Self(rawValue: 0x8000)
 }


### PR DESCRIPTION
Namely, types references to UWP assemblies can be resolved by full name, bypassing the assembly reference resolution since that tends to be inconsistent between WinMDs.