### PR TITLE
Introduce TypeName type and use AssemblyLoadContext.resolveType

### DIFF
--- a/Sources/DotNetMetadata/Assembly+resolve.swift
+++ b/Sources/DotNetMetadata/Assembly+resolve.swift
@@ -60,8 +60,7 @@ extension Assembly {
                 return try context.resolveType(
                     assembly: assemblyReference.identity,
                     assemblyFlags: assemblyReference.flags,
-                    namespace: namespace,
-                    name: name)
+                    name: TypeName(namespace: namespace, shortName: name))
             default:
                 fatalError("Not implemented: resolution scope \(row.resolutionScope)")
         }

--- a/Sources/DotNetMetadata/Assembly.swift
+++ b/Sources/DotNetMetadata/Assembly.swift
@@ -123,14 +123,12 @@ public class Assembly: CustomDebugStringConvertible {
         return nil
     }
 
-    public func resolveTypeDefinition(namespace: String?, name: String, allowForwarding: Bool = true) throws -> TypeDefinition? {
-        let fullName = makeFullTypeName(namespace: namespace, name: name)
-        return try resolveTypeDefinition(fullName: fullName, allowForwarding: allowForwarding)
+    public func resolveTypeDefinition(name: TypeName, allowForwarding: Bool = true) throws -> TypeDefinition? {
+        try resolveTypeDefinition(fullName: name.fullName, allowForwarding: allowForwarding)
     }
 
-    public func resolveTypeDefinition(namespace: String?, enclosingName: String, nestedNames: [String], allowForwarding: Bool = true) throws -> TypeDefinition? {
-        let fullName = makeFullTypeName(namespace: namespace, enclosingName: enclosingName, nestedNames: nestedNames)
-        return try resolveTypeDefinition(fullName: fullName, allowForwarding: allowForwarding)
+    public func resolveTypeDefinition(namespace: String, name: String, allowForwarding: Bool = true) throws -> TypeDefinition? {
+        try resolveTypeDefinition(name: TypeName(namespace: namespace, shortName: name), allowForwarding: allowForwarding)
     }
 
     internal func getAttributes(owner: CodedIndices.HasCustomAttribute) -> [Attribute] {

--- a/Sources/DotNetMetadata/Attribute.swift
+++ b/Sources/DotNetMetadata/Attribute.swift
@@ -69,9 +69,11 @@ public final class Attribute {
             case .constant(let constant): return .constant(constant)
 
             case let .type(fullName, assemblyIdentity):
-                let assembly: Assembly
+                let typeDefinition: TypeDefinition
                 if let assemblyIdentity {
-                    assembly = try self.assembly.context.load(identity: assemblyIdentity)
+                    typeDefinition = try self.assembly.context.resolveType(
+                        assembly: assemblyIdentity, assemblyFlags: nil,
+                        name: TypeName(fullName: fullName))
                 }
                 else {
                     // TODO: Fallback to mscorlib
@@ -79,9 +81,9 @@ public final class Attribute {
                     // > If the assembly name is omitted, the CLI looks first in the current assembly,
                     // > and then in the system library (mscorlib); in these two special cases,
                     // > it is permitted to omit the assembly-name, version, culture and public-key-token.
-                    assembly = self.assembly
+                    typeDefinition = try self.assembly.resolveTypeDefinition(fullName: fullName)!
                 }
-                return .type(definition: try assembly.resolveTypeDefinition(fullName: fullName)!)
+                return .type(definition: typeDefinition)
 
             case .array(let elems): return .array(try elems.map(resolve))
             case .boxed(_): fatalError("Not implemented: boxed custom attribute arguments")

--- a/Sources/DotNetMetadata/BoundType.swift
+++ b/Sources/DotNetMetadata/BoundType.swift
@@ -42,7 +42,7 @@ extension BoundTypeOf: CustomStringConvertible {
             result += "."
         }
 
-        result += definition.nameWithoutGenericSuffix
+        result += definition.nameWithoutGenericArity
 
         if genericArgs.count > 0 {
             result += "<"

--- a/Sources/DotNetMetadata/ExportedType.swift
+++ b/Sources/DotNetMetadata/ExportedType.swift
@@ -26,7 +26,7 @@ public final class ExportedType {
 
     public private(set) lazy var fullName: String = {
         // TODO: Support nested exported types
-        makeFullTypeName(namespace: namespace, name: name)
+        TypeName.toFullName(namespace: namespace, shortName: name)
     }()
 
     private var cachedDefinition: TypeDefinition?
@@ -44,8 +44,7 @@ public final class ExportedType {
                     return try context.resolveType(
                         assembly: assemblyReference.identity,
                         assemblyFlags: assemblyReference.flags,
-                        namespace: namespace,
-                        name: name)
+                        name: TypeName(namespace: namespace, shortName: name))
                 default:
                     fatalError("Not implemented: \(#function)")
             }

--- a/Sources/DotNetMetadata/TypeName.swift
+++ b/Sources/DotNetMetadata/TypeName.swift
@@ -1,0 +1,70 @@
+/// Represents the name of a .NET Type, including its namespace and nested type names.
+public struct TypeName: Hashable, CustomStringConvertible {
+    public static let namespaceSeparator: Character = "."
+    public static let nestedTypeSeparator: Character = "/"
+    public static let genericAritySeparator: Character = "`"
+
+    public let namespace: String?
+    /// The short type name and any nested type names.
+    public let shortNames: [String] // Invariant: non-empty
+    // TODO: Splitoff generic arity?
+
+    public init(namespace: String?, shortNames: [String]) {
+        assert(!shortNames.isEmpty)
+        self.namespace = namespace
+        self.shortNames = shortNames
+    }
+
+    public init(namespace: String?, shortName: String) {
+        assert(!shortName.contains(Self.namespaceSeparator))
+        assert(!shortName.contains(Self.nestedTypeSeparator))
+        self.namespace = namespace
+        self.shortNames = [shortName]
+    }
+
+    public init(namespace: String?, outermostShortName: String, nestedNames: [String]) {
+        self.init(namespace: namespace, shortNames: [outermostShortName] + nestedNames)
+    }
+
+    public init(fullName: String) {
+        let namespaceEnd = fullName.lastIndex(of: Self.namespaceSeparator)
+        let shortNamesStart = namespaceEnd.map { fullName.index(after: $0) } ?? fullName.startIndex
+        self.init(
+            namespace: namespaceEnd.map { String(fullName[...$0]) },
+            shortNames: fullName[shortNamesStart...].split(separator: Self.nestedTypeSeparator).map(String.init))
+    }
+
+    public var outermostShortName: String { shortNames.first! }
+    public var nestedNames: ArraySlice<String> { shortNames.dropFirst() }
+
+    public var fullName: String {
+        var result: String = ""
+        if let namespace {
+            result = namespace
+            result.append(TypeName.namespaceSeparator)
+        }
+
+        for (index, shortName) in shortNames.enumerated() {
+            if index > 0 { result.append(Self.nestedTypeSeparator) }
+            result += shortName
+        }
+
+        return result
+    }
+
+    public var description: String { fullName }
+
+    public static func toFullName(namespace: String?, shortName: String) -> String {
+        if let namespace { return "\(namespace)\(namespaceSeparator)\(shortName)" }
+        else { return shortName }
+    }
+
+    public static func toFullName(namespace: String?, outermostShortName: String, nestedNames: [String]) -> String {
+        Self(namespace: namespace, outermostShortName: outermostShortName, nestedNames: nestedNames).fullName
+    }
+
+    public static func trimGenericArity(_ name: String) -> String {
+        guard let genericAritySeparatorIndex = name.lastIndex(of: genericAritySeparator) else { return name }
+        return String(name[..<genericAritySeparatorIndex])
+    }
+}

--- a/Sources/DotNetXMLDocs/DocumentationTypeNode.swift
+++ b/Sources/DotNetXMLDocs/DocumentationTypeNode.swift
@@ -13,11 +13,11 @@ public enum DocumentationTypeNode: Hashable {
 extension DocumentationTypeNode {
     public static func bound(
             namespace: String? = nil,
-            nameWithoutGenericSuffix: String,
+            nameWithoutGenericArity: String,
             genericity: DocumentationTypeReference.Genericity = .bound([])) -> Self {
         .bound(DocumentationTypeReference(
             namespace: namespace,
-            nameWithoutGenericSuffix: nameWithoutGenericSuffix,
+            nameWithoutGenericArity: nameWithoutGenericArity,
             genericity: genericity))
     }
 }

--- a/Sources/DotNetXMLDocs/DocumentationTypeReference+parsing.swift
+++ b/Sources/DotNetXMLDocs/DocumentationTypeReference+parsing.swift
@@ -15,7 +15,7 @@ extension DocumentationTypeReference {
 
         return Self(
             namespace: identifier.namespace.map(String.init),
-            nameWithoutGenericSuffix: String(identifier.name),
+            nameWithoutGenericArity: String(identifier.name),
             genericity: genericity)
     }
 

--- a/Sources/DotNetXMLDocs/DocumentationTypeReference.swift
+++ b/Sources/DotNetXMLDocs/DocumentationTypeReference.swift
@@ -1,25 +1,25 @@
 public struct DocumentationTypeReference: Hashable {
     public var namespace: String?
-    public var nameWithoutGenericSuffix: String
+    public var nameWithoutGenericArity: String
     public var genericity: Genericity
 
-    public init(namespace: String? = nil, nameWithoutGenericSuffix: String, genericity: Genericity = .bound([])) {
+    public init(namespace: String? = nil, nameWithoutGenericArity: String, genericity: Genericity = .bound([])) {
         self.namespace = namespace
-        self.nameWithoutGenericSuffix = nameWithoutGenericSuffix
+        self.nameWithoutGenericArity = nameWithoutGenericArity
         self.genericity = genericity
     }
 
-    public init(namespace: String? = nil, nameWithoutGenericSuffix: String, genericArity: Int) {
+    public init(namespace: String? = nil, nameWithoutGenericArity: String, genericArity: Int) {
         self.init(
             namespace: namespace,
-            nameWithoutGenericSuffix: nameWithoutGenericSuffix,
+            nameWithoutGenericArity: nameWithoutGenericArity,
             genericity: genericArity == 0 ? .bound([]) : .unbound(arity: genericArity))
     }
 
-    public init(namespace: String? = nil, nameWithoutGenericSuffix: String, genericArgs: [DocumentationTypeNode]) {
+    public init(namespace: String? = nil, nameWithoutGenericArity: String, genericArgs: [DocumentationTypeNode]) {
         self.init(
             namespace: namespace,
-            nameWithoutGenericSuffix: nameWithoutGenericSuffix,
+            nameWithoutGenericArity: nameWithoutGenericArity,
             genericity: .bound(genericArgs))
     }
 

--- a/Sources/DotNetXMLDocs/MemberDocumentationKey.swift
+++ b/Sources/DotNetXMLDocs/MemberDocumentationKey.swift
@@ -25,11 +25,11 @@ public enum MemberDocumentationKey: Hashable {
 extension MemberDocumentationKey {
     public static func type(
             namespace: String? = nil,
-            nameWithoutGenericSuffix: String,
+            nameWithoutGenericArity: String,
             genericity: DocumentationTypeReference.Genericity = .bound([])) -> Self {
         .type(DocumentationTypeReference(
             namespace: namespace,
-            nameWithoutGenericSuffix: nameWithoutGenericSuffix,
+            nameWithoutGenericArity: nameWithoutGenericArity,
             genericity: genericity))
     }
 }

--- a/Tests/DotNetXMLDocs/AssemblyDocumentationTests.swift
+++ b/Tests/DotNetXMLDocs/AssemblyDocumentationTests.swift
@@ -26,7 +26,7 @@ final class AssemblyDocumentationTests: XCTestCase {
         XCTAssertEqual(assemblyDocumentation.assemblyName, "AssemblyName")
         XCTAssertEqual(assemblyDocumentation.members.count, 2)
 
-        XCTAssertNotNil(assemblyDocumentation.members[.type(nameWithoutGenericSuffix: "TypeA")])
-        XCTAssertNotNil(assemblyDocumentation.members[.type(nameWithoutGenericSuffix: "TypeB")])
+        XCTAssertNotNil(assemblyDocumentation.members[.type(nameWithoutGenericArity: "TypeA")])
+        XCTAssertNotNil(assemblyDocumentation.members[.type(nameWithoutGenericArity: "TypeB")])
     }
 }

--- a/Tests/DotNetXMLDocs/DocumentationTypeNodeTests.swift
+++ b/Tests/DotNetXMLDocs/DocumentationTypeNodeTests.swift
@@ -5,19 +5,19 @@ final class DocumentationTypeNodeTests: XCTestCase {
     func testParseBound() throws {
         XCTAssertEqual(
             try DocumentationTypeNode(parsing: "Name"),
-            .bound(nameWithoutGenericSuffix: "Name"))
+            .bound(nameWithoutGenericArity: "Name"))
     }
 
     func testParseArray() throws {
         XCTAssertEqual(
             try DocumentationTypeNode(parsing: "Name[]"),
-            .array(of: .bound(nameWithoutGenericSuffix: "Name")))
+            .array(of: .bound(nameWithoutGenericArity: "Name")))
     }
 
     func testParsePointer() throws {
         XCTAssertEqual(
             try DocumentationTypeNode(parsing: "Name*"),
-            .pointer(to: .bound(nameWithoutGenericSuffix: "Name")))
+            .pointer(to: .bound(nameWithoutGenericArity: "Name")))
     }
 
     func testParseGenericParam() throws {

--- a/Tests/DotNetXMLDocs/DocumentationTypeReferenceTests.swift
+++ b/Tests/DotNetXMLDocs/DocumentationTypeReferenceTests.swift
@@ -5,24 +5,24 @@ final class DocumentationTypeReferenceTests: XCTestCase {
     func testParseNonGeneric() throws {
         XCTAssertEqual(
             try DocumentationTypeReference(parsing: "Name"),
-            .init(nameWithoutGenericSuffix: "Name"))
+            .init(nameWithoutGenericArity: "Name"))
     }
 
     func testParseUnboundGeneric() throws {
         XCTAssertEqual(
             try DocumentationTypeReference(parsing: "Name`1"),
-            .init(nameWithoutGenericSuffix: "Name", genericity: .unbound(arity: 1)))
+            .init(nameWithoutGenericArity: "Name", genericity: .unbound(arity: 1)))
     }
 
     func testParseBoundGeneric() throws {
         XCTAssertEqual(
             try DocumentationTypeReference(parsing: "Name`1{Name2}"),
-            .init(nameWithoutGenericSuffix: "Name", genericArgs: [ .bound(nameWithoutGenericSuffix: "Name2") ]))
+            .init(nameWithoutGenericArity: "Name", genericArgs: [ .bound(nameWithoutGenericArity: "Name2") ]))
     }
 
     func testParseNamespaced() throws {
         XCTAssertEqual(
             try DocumentationTypeReference(parsing: "Namespace.Name"),
-            .init(namespace: "Namespace", nameWithoutGenericSuffix: "Name"))
+            .init(namespace: "Namespace", nameWithoutGenericArity: "Name"))
     }
 }

--- a/Tests/DotNetXMLDocs/MemberDocumentationKeyTests.swift
+++ b/Tests/DotNetXMLDocs/MemberDocumentationKeyTests.swift
@@ -11,28 +11,28 @@ final class MemberDocumentationKeyTests: XCTestCase {
     func testParseType() throws {
         XCTAssertEqual(
             try MemberDocumentationKey(parsing: "T:Type"),
-            .type(nameWithoutGenericSuffix: "Type"))
+            .type(nameWithoutGenericArity: "Type"))
         XCTAssertEqual(
             try MemberDocumentationKey(parsing: "T:Namespace.Type"),
-            .type(namespace: "Namespace", nameWithoutGenericSuffix: "Type"))
+            .type(namespace: "Namespace", nameWithoutGenericArity: "Type"))
         XCTAssertEqual(
             try MemberDocumentationKey(parsing: "T:Namespace.GenericType`1"),
-            .type(namespace: "Namespace", nameWithoutGenericSuffix: "GenericType", genericity: .unbound(arity: 1)))
+            .type(namespace: "Namespace", nameWithoutGenericArity: "GenericType", genericity: .unbound(arity: 1)))
     }
 
     func testParseParameterlessMember() throws {
         XCTAssertEqual(
             try MemberDocumentationKey(parsing: "F:Type.Field"),
-            .field(declaringType: .init(nameWithoutGenericSuffix: "Type"), name: "Field"))
+            .field(declaringType: .init(nameWithoutGenericArity: "Type"), name: "Field"))
         XCTAssertEqual(
             try MemberDocumentationKey(parsing: "P:Type.Property"),
-            .property(declaringType: .init(nameWithoutGenericSuffix: "Type"), name: "Property"))
+            .property(declaringType: .init(nameWithoutGenericArity: "Type"), name: "Property"))
         XCTAssertEqual(
             try MemberDocumentationKey(parsing: "E:Type.Event"),
-            .event(declaringType: .init(nameWithoutGenericSuffix: "Type"), name: "Event"))
+            .event(declaringType: .init(nameWithoutGenericArity: "Type"), name: "Event"))
         XCTAssertEqual(
             try MemberDocumentationKey(parsing: "M:Type.Method"),
-            .method(declaringType: .init(nameWithoutGenericSuffix: "Type"), name: "Method"))
+            .method(declaringType: .init(nameWithoutGenericArity: "Type"), name: "Method"))
 
         // Should have a type name followed by a member name
         XCTAssertThrowsError(
@@ -42,37 +42,37 @@ final class MemberDocumentationKeyTests: XCTestCase {
     func testParseGenericTypeMember() throws {
         XCTAssertEqual(
             try MemberDocumentationKey(parsing: "M:Namespace.Type`1.Method"),
-            .method(declaringType: .init(namespace: "Namespace", nameWithoutGenericSuffix: "Type", genericity: .unbound(arity: 1)), name: "Method"))
+            .method(declaringType: .init(namespace: "Namespace", nameWithoutGenericArity: "Type", genericity: .unbound(arity: 1)), name: "Method"))
     }
 
     func testParseInParam() throws {
         XCTAssertEqual(
             try MemberDocumentationKey(parsing: "M:DeclaringType.Method(ParamType)"),
-            .method(declaringType: .init(nameWithoutGenericSuffix: "DeclaringType"), name: "Method", params: [
-                .init(type: .bound(nameWithoutGenericSuffix: "ParamType"))
+            .method(declaringType: .init(nameWithoutGenericArity: "DeclaringType"), name: "Method", params: [
+                .init(type: .bound(nameWithoutGenericArity: "ParamType"))
             ]))
     }
 
     func testParseArrayParam() throws {
         XCTAssertEqual(
             try MemberDocumentationKey(parsing: "M:DeclaringType.Method(ParamType[])"),
-            .method(declaringType: .init(nameWithoutGenericSuffix: "DeclaringType"), name: "Method", params: [
-                .init(type: .array(of: .bound(nameWithoutGenericSuffix: "ParamType")))
+            .method(declaringType: .init(nameWithoutGenericArity: "DeclaringType"), name: "Method", params: [
+                .init(type: .array(of: .bound(nameWithoutGenericArity: "ParamType")))
             ]))
     }
 
     func testParseOutParam() throws {
         XCTAssertEqual(
             try MemberDocumentationKey(parsing: "M:DeclaringType.Method(ParamType@)"),
-            .method(declaringType: .init(nameWithoutGenericSuffix: "DeclaringType"), name: "Method", params: [
-                .init(type: .bound(nameWithoutGenericSuffix: "ParamType"), isByRef: true)
+            .method(declaringType: .init(nameWithoutGenericArity: "DeclaringType"), name: "Method", params: [
+                .init(type: .bound(nameWithoutGenericArity: "ParamType"), isByRef: true)
             ]))
     }
 
     func testParseGenericTypeParam() throws {
         XCTAssertEqual(
             try MemberDocumentationKey(parsing: "M:DeclaringType`1.Method(`0)"),
-            .method(declaringType: .init(nameWithoutGenericSuffix: "DeclaringType", genericity: .unbound(arity: 1)), name: "Method", params: [
+            .method(declaringType: .init(nameWithoutGenericArity: "DeclaringType", genericity: .unbound(arity: 1)), name: "Method", params: [
                 .init(type: .genericParam(index: 0, kind: .type))
             ]))
     }
@@ -80,24 +80,24 @@ final class MemberDocumentationKeyTests: XCTestCase {
     func testParseConstructor() throws {
         XCTAssertEqual(
             try MemberDocumentationKey(parsing: "M:TypeName.#ctor"),
-            .method(declaringType: .init(nameWithoutGenericSuffix: "TypeName"), name: MemberDocumentationKey.constructorName))
+            .method(declaringType: .init(nameWithoutGenericArity: "TypeName"), name: MemberDocumentationKey.constructorName))
     }
 
     func testParseConversionOperator() throws {
         XCTAssertEqual(
             try MemberDocumentationKey(parsing: "M:TypeName.op_Implicit()~ReturnType"),
             .method(
-                declaringType: .init(nameWithoutGenericSuffix: "TypeName"),
+                declaringType: .init(nameWithoutGenericArity: "TypeName"),
                 name: "op_Implicit",
                 params: [],
-                conversionTarget: .init(type: .bound(nameWithoutGenericSuffix: "ReturnType"))))
+                conversionTarget: .init(type: .bound(nameWithoutGenericArity: "ReturnType"))))
     }
 
     func testParseIndexer() throws {
         XCTAssertEqual(
             try MemberDocumentationKey(parsing: "M:TypeName.Property(System.Int32)"),
-            .method(declaringType: .init(nameWithoutGenericSuffix: "TypeName"), name: "Property", params: [
-                .init(type: .bound(namespace: "System", nameWithoutGenericSuffix: "Int32"))
+            .method(declaringType: .init(nameWithoutGenericArity: "TypeName"), name: "Property", params: [
+                .init(type: .bound(namespace: "System", nameWithoutGenericArity: "Int32"))
             ]))
     }
 }

--- a/Tests/DotNetXMLDocs/MemberDocumentationTests.swift
+++ b/Tests/DotNetXMLDocs/MemberDocumentationTests.swift
@@ -28,7 +28,7 @@ final class MemberDocumentationTests: XCTestCase {
         XCTAssertEqual(memberDocumentation.params, [.init(name: "ParamName", description: .plain("ParamDesc"))])
         XCTAssertEqual(memberDocumentation.returns, .plain("Returns"))
         XCTAssertEqual(memberDocumentation.exceptions, [
-            .init(type: .init(nameWithoutGenericSuffix: "MyException"), description: .plain("Exception"))
+            .init(type: .init(nameWithoutGenericArity: "MyException"), description: .plain("Exception"))
         ])
     }
 


### PR DESCRIPTION
`TypeName` owns parsing and formatting .NET type names.
Fixed one type reference path that used `AssemblyLoadContext.load` instead of `.resolveType` (needed for WinRT UWP references).